### PR TITLE
python3 support using 2to3

### DIFF
--- a/kismetclient/client.py
+++ b/kismetclient/client.py
@@ -24,7 +24,7 @@ class Command(object):
                 return '\x01%s\x01'
             else:
                 return opt
-        self.opts = map(wrap, opts)
+        self.opts = list(map(wrap, opts))
 
     def __str__(self):
         return '!%d %s %s' % (self.command_id,
@@ -70,7 +70,7 @@ class Client(object):
                               handlers.error,
                               send_enable=False)
         # Open a socket to the kismet server with line-based buffering
-        self.file = socket.create_connection(address).makefile('w', 1)
+        self.file = socket.create_connection(address).makefile('rw', 1)
 
         # Bootstrap the server protocols
         self.listen()  # Kismet startup line
@@ -112,5 +112,5 @@ class Client(object):
                 # If the protocol fields aren't known at all, we don't
                 # handle the message.
                 if field_names:
-                    named_fields = dict(zip(field_names, fields))
+                    named_fields = dict(list(zip(field_names, fields)))
                     return handler(self, **named_fields)

--- a/kismetclient/handlers.py
+++ b/kismetclient/handlers.py
@@ -37,6 +37,6 @@ def error(client, cmdid, text):
 
 def print_fields(client, **fields):
     """ A generic handler which prints all the fields. """
-    for k, v in fields.items():
-        print '%s: %s' % (k, v)
-    print '-' * 80
+    for k, v in list(fields.items()):
+        print('%s: %s' % (k, v))
+    print('-' * 80)

--- a/kismetclient/utils.py
+++ b/kismetclient/utils.py
@@ -2,7 +2,7 @@ import inspect
 
 
 def csv(val):
-    if isinstance(val, basestring):
+    if isinstance(val, str):
         return val.split(',')
     elif hasattr(val, '__iter__'):
         return ','.join(map(str, val))

--- a/runclient.py
+++ b/runclient.py
@@ -19,7 +19,7 @@ k.register_handler('TRACKINFO', handlers.print_fields)
 
 
 def handle_ssid(client, ssid, mac):
-    print 'ssid spotted: "%s" with mac %s' % (ssid, mac)
+    print('ssid spotted: "%s" with mac %s' % (ssid, mac))
 
 k.register_handler('SSID', handle_ssid)
 


### PR DESCRIPTION
Needed to use the client in Python3 which necessitated changes:
- Ran a straight 2to3 output
- `makefile('rw' 1)` instead of `makefile('r', 1)` in `client.py`

Tested on Python 3.4.0
